### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ Licensed under GPL-3.0
 ## 🔗 Star History
 
 <div align="center">
-  <a href="https://star-history.com/nikhilvishwakarma00/velune&Date">
+  <a href="https://star-history.dera.page/#nikhilvishwakarma00/velune&type=Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nikhilvishwakarma00/velune&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nikhilvishwakarma00/velune&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=nikhilvishwakarma00/velune&type=Date" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=nikhilvishwakarma00/velune&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=nikhilvishwakarma00/velune&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=nikhilvishwakarma00/velune&type=Date" />
     </picture>
   </a>
 


### PR DESCRIPTION
The star history chart is currently broken because of GitHub stargazer API restrictions. This change points it to a working alternative so the chart renders again.